### PR TITLE
Add my default env to docker container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,16 +18,16 @@ services:
       # - 5335:5335/tcp # Uncomment to enable unbound access on local server
       # - 22/tcp # Uncomment to enable SSH
     environment:
-      - FTLCONF_LOCAL_IPV4=${FTLCONF_LOCAL_IPV4}
+      - FTLCONF_LOCAL_IPV4=${FTLCONF_LOCAL_IPV4:-192.168.99.5}
       - TZ=${TZ:-UTC}
       - WEBPASSWORD=${WEBPASSWORD}
-      - WEBTHEME=${WEBTHEME:-default-light}
-      - REV_SERVER=${REV_SERVER:-false}
-      - REV_SERVER_TARGET=${REV_SERVER_TARGET}
-      - REV_SERVER_DOMAIN=${REV_SERVER_DOMAIN}
-      - REV_SERVER_CIDR=${REV_SERVER_CIDR}
-      - PIHOLE_DNS_=127.0.0.1#5335
-      - DNSSEC="true"
+      # - WEBTHEME=${WEBTHEME:-default-light}
+      # - REV_SERVER=${REV_SERVER:-false}
+      # - REV_SERVER_TARGET=${REV_SERVER_TARGET}
+      # - REV_SERVER_DOMAIN=${REV_SERVER_DOMAIN}
+      # - REV_SERVER_CIDR=${REV_SERVER_CIDR}
+      # - PIHOLE_DNS_=127.0.0.1#5335
+      # - DNSSEC="true"
       - DNSMASQ_LISTENING=single
       - VIRTUAL_HOST=${VIRTUAL_HOST}
     volumes:

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -9,3 +9,8 @@ RUN mkdir -p /etc/services.d/unbound
 COPY unbound-run /etc/services.d/unbound/run
 
 ENTRYPOINT ./s6-init
+
+ENV WEBTHEME=default-auto
+ENV REV_SERVER=false
+ENV PIHOLE_DNS=127.0.0.1#5335;1.1.1.1;9.9.9.9
+ENV DNSSEC=true


### PR DESCRIPTION
This update adds my preferred environment variables to the container image itself so I don't have to add them on deployment