### PR TITLE
Unbound version 1.19.1 - fix #40

### DIFF
--- a/.github/workflows/auto-build-container.yml
+++ b/.github/workflows/auto-build-container.yml
@@ -60,7 +60,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: "{{defaultContext}}:pihole-unbound/"
-        platforms: linux/arm/v7,linux/arm64/v8,linux/amd64
+        platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
         push: true
         tags: aleksanderbl/pihole-unbound:latest,aleksanderbl/pihole-unbound:${{ steps.latest_release.outputs.release }}
       if: ${{ steps.latest_release.outputs.release != steps.previous_release.outputs.release }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -4,8 +4,6 @@ name: Build and publish container in development
 on:
   # cron job to trigger the build on any push to main
   pull_request:
-    branches:
-      - main
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ docker-compose up -d
 - [ ] Run the commands below
 
 ```bash
-cd docker-pihole-unbound
-docker build . -t dev/docker-pihole-unbound:latest
+docker build ./pihole-unbound/ -t dev/docker-pihole-unbound:latest
 ```
 
 ## Automatic dev builds with Github Actions

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - 127.0.0.1
     container_name: pihole
     image: aleksanderbl/pihole-unbound:2024.03.2
+    # image: dev/docker-pihole-unbound:latest
     hostname: ${HOSTNAME}
     domainname: ${DOMAIN_NAME}
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,8 @@ services:
     dns:
       - 127.0.0.1
     container_name: pihole
-    image: aleksanderbl/pihole-unbound:2024.03.2
-    # image: dev/docker-pihole-unbound:latest
+    # image: aleksanderbl/pihole-unbound:2024.03.2
+    image: dev/docker-pihole-unbound:latest
     hostname: ${HOSTNAME}
     domainname: ${DOMAIN_NAME}
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     dns:
       - 127.0.0.1
     container_name: pihole
-    image: aleksanderbl/pihole-unbound:2024.02.0
+    image: aleksanderbl/pihole-unbound:2024.02.2
     hostname: ${HOSTNAME}
     domainname: ${DOMAIN_NAME}
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     dns:
       - 127.0.0.1
     container_name: pihole
-    image: aleksanderbl/pihole-unbound:2024.01.0
+    image: aleksanderbl/pihole-unbound:2024.02.0
     hostname: ${HOSTNAME}
     domainname: ${DOMAIN_NAME}
     ports:

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -3,7 +3,7 @@ FROM pihole/pihole:2024.05.0
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 
 RUN apt-get update
-RUN apt-get upgrade libreadline8t64 -y
+RUN apt-get upgrade -f libreadline8t64
 RUN apt-get -t sid install -y unbound -V
 
 

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,4 +1,4 @@
-FROM pihole/pihole:2024.02.0
+FROM pihole/pihole:2024.02.2
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get -t sid install -y unbound
 

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,8 +1,8 @@
 FROM pihole/pihole:2024.03.2
 
-RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian trixie main" >> /etc/apt/sources.list
 
-RUN apt-get update && apt-get upgrade -y && apt-get -t sid install -y unbound -V
+RUN apt-get update && apt-get upgrade -y && apt-get -t trixie install -y unbound -V
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf
 COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -2,7 +2,9 @@ FROM pihole/pihole:2024.05.0
 
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 
-RUN apt-get update && apt-get upgrade -y && apt-get -t sid install -y unbound -V
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get -t sid install -y unbound -V
 
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,12 +1,16 @@
 FROM pihole/pihole:2024.02.2
+
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get -t sid install -y unbound
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf
 COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf
 COPY 99-edns.conf /etc/dnsmasq.d/99-edns.conf
+
 RUN mkdir -p /etc/services.d/unbound
+
 COPY unbound-run /etc/services.d/unbound/run
+
 RUN chmod 774 /etc/services.d/unbound/run
 
 ENTRYPOINT ./s6-init

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -3,7 +3,7 @@ FROM pihole/pihole:2024.05.0
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 
 RUN apt-get update
-RUN apt-get upgrade -y
+RUN apt-get upgrade -y -V
 RUN apt-get -t sid install -y unbound -V
 
 

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,11 +1,11 @@
 FROM pihole/pihole:2024.05.0
 
-RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian trixie main" >> /etc/apt/sources.list
 
 # RUN apt-get update
 # RUN apt-get upgrade libreadline8 -y
 # RUN apt-get upgrade libreadline8t64 -y
-RUN apt-get -t sid install -y unbound -V
+RUN apt-get -t trixie install -y unbound -V
 
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -3,8 +3,7 @@ FROM pihole/pihole:2024.05.0
 RUN echo "deb http://deb.debian.org/debian trixie main" >> /etc/apt/sources.list
 
 RUN apt-get update
-# RUN apt-get upgrade libreadline8 -y
-# RUN apt-get upgrade libreadline8t64 -y
+RUN apt-get upgrade -y
 RUN apt-get -t trixie install -y unbound -V
 
 

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -3,7 +3,8 @@ FROM pihole/pihole:2024.05.0
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 
 RUN apt-get update
-RUN apt-get upgrade -f libreadline8t64
+RUN apt-get upgrade libreadline8 -y
+RUN apt-get upgrade libreadline8t64 -y
 RUN apt-get -t sid install -y unbound -V
 
 

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,6 +1,6 @@
 FROM pihole/pihole:2024.02.0
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get -t bullseye-backports install -y unbound
+RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
+RUN apt-get update && apt-get -t sid install -y unbound
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf
 COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -3,7 +3,7 @@ FROM pihole/pihole:2024.05.0
 RUN echo "deb http://deb.debian.org/debian trixie main" >> /etc/apt/sources.list
 
 RUN apt-get update
-RUN apt-get upgrade -y
+# RUN apt-get upgrade -y
 RUN apt-get -t trixie install -y unbound -V
 
 

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -2,7 +2,7 @@ FROM pihole/pihole:2024.05.0
 
 RUN echo "deb http://deb.debian.org/debian trixie main" >> /etc/apt/sources.list
 
-# RUN apt-get update
+RUN apt-get update
 # RUN apt-get upgrade libreadline8 -y
 # RUN apt-get upgrade libreadline8t64 -y
 RUN apt-get -t trixie install -y unbound -V

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,4 +1,4 @@
-FROM pihole/pihole:2024.02.2
+FROM pihole/pihole:2024.03.2
 
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get -t sid install -y unbound

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,8 +1,8 @@
 FROM pihole/pihole:2024.05.0
 
-RUN echo "deb http://deb.debian.org/debian trixie main" >> /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 
-RUN apt-get update && apt-get upgrade -y && apt-get -t trixie install -y unbound -V
+RUN apt-get update && apt-get upgrade -y && apt-get -t sid install -y unbound -V
 
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,6 +1,7 @@
 FROM pihole/pihole:2024.03.2
 
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
+
 RUN apt-get update && apt-get upgrade -y && apt-get -t sid install -y unbound -V
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -3,7 +3,7 @@ FROM pihole/pihole:2024.05.0
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 
 RUN apt-get update
-RUN apt-get upgrade -y -V
+# RUN apt-get upgrade -y -V
 RUN apt-get -t sid install -y unbound -V
 
 

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,7 +1,7 @@
 FROM pihole/pihole:2024.02.2
 
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get -t sid install -y unbound
+RUN apt-get update && apt-get upgrade -y && apt-get -t sid install -y unbound
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf
 COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -2,9 +2,9 @@ FROM pihole/pihole:2024.05.0
 
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 
-RUN apt-get update
-RUN apt-get upgrade libreadline8 -y
-RUN apt-get upgrade libreadline8t64 -y
+# RUN apt-get update
+# RUN apt-get upgrade libreadline8 -y
+# RUN apt-get upgrade libreadline8t64 -y
 RUN apt-get -t sid install -y unbound -V
 
 

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,10 +1,15 @@
-FROM pihole/pihole:2024.07.0
+FROM pihole/pihole:2024.07.0 AS base
 
 RUN echo "deb http://deb.debian.org/debian trixie main" >> /etc/apt/sources.list
 
 RUN apt-get update
+RUN apt-get install -s usrmerge
+
+FROM base
+RUN apt-get update
 # RUN apt-get upgrade -y
 RUN apt-get -t trixie install -y unbound -V
+# RUN apt-get install -y unbound -V
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf
 COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,7 +1,7 @@
 FROM pihole/pihole:2024.02.2
 
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get upgrade -y && apt-get -t sid install -y unbound
+RUN apt-get update && apt-get -t sid install -y unbound
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf
 COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -3,7 +3,7 @@ FROM pihole/pihole:2024.05.0
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
 
 RUN apt-get update
-# RUN apt-get upgrade -y -V
+RUN apt-get upgrade libreadline8t64 -y
 RUN apt-get -t sid install -y unbound -V
 
 

--- a/pihole-unbound/Dockerfile
+++ b/pihole-unbound/Dockerfile
@@ -1,7 +1,7 @@
 FROM pihole/pihole:2024.03.2
 
 RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list
-RUN apt-get update && apt-get -t sid install -y unbound
+RUN apt-get update && apt-get upgrade -y && apt-get -t sid install -y unbound -V
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf
 COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf


### PR DESCRIPTION
This PR creates a dev-container that installs the latest unbound version from the _sid_ repo. This is currently 1.19.1 as mentioned in #40 

The image is available as [dev-pr-45-2024-02-18](https://hub.docker.com/layers/aleksanderbl/pihole-unbound/dev-pr-45-2024-02-18/images/sha256-a1dffb4cc7208d2868f7efc6afa36dcca4bfa93daf277a673f517549775f2b37?context=explore)